### PR TITLE
Update descriptions of agl-sota.

### DIFF
--- a/docs/getting-started/image-workflow-initialize-build-environment.md
+++ b/docs/getting-started/image-workflow-initialize-build-environment.md
@@ -133,8 +133,8 @@ Following are brief descriptions of the AGL features you can specify on the
   [Ptest](https://yoctoproject.org/docs/2.4.4/dev-manual/dev-manual.html#testing-packages-with-ptest)
   as part of the build.
 
-* **agl-sota**: Enables State of the Art (SOTA) components and dependencies.
-  Includes meta-sota, meta-file systems, meta-ruby, and meta-rust.
+* **agl-sota**: Enables Software Over-the-Air (SOTA) components and dependencies.
+  Includes meta-updater, meta-updater-qemux86-64, meta-filesystems, and meta-python.
 
 * **agl-demo**: Enables the layers meta-agl-demo and meta-qt5.
   You need agl-demo if you are going to build the agl-demo-platform.


### PR DESCRIPTION
Corrected the definition of SOTA and the layers required for the agl-sota feature.

~~Where is the source text for https://github.com/automotive-grade-linux/docs-gh-pages/blob/gh-pages/docs/en/master/devguides/meta-agl-demo.html, though? I cannot seem to find it in this repo.~~

If this PR looks good, I'll make similar ones for flouder/guppy/halibut.

Update: found the source of the dev guide text I also wanted to change and submitted a patch for master: https://gerrit.automotivelinux.org/gerrit/c/AGL/meta-agl-demo/+/22894